### PR TITLE
68/missing data

### DIFF
--- a/GitHub Scraper/GitHubScraper.Tests/Converters/GitHub Converter Test.cs
+++ b/GitHub Scraper/GitHubScraper.Tests/Converters/GitHub Converter Test.cs
@@ -126,6 +126,18 @@ namespace GitHubScraper.Tests.Converters
         }
 
         /// <summary>
+        /// Tests whether the GetQuery method returns the correct value when given "/branches".
+        /// </summary>
+        [TestMethod]
+        public void TestGetQueryBranches()
+        {
+            string expected = "?per_page=100";
+            string actual = GitHubConverter.GetQuery("/branches");
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        /// <summary>
         /// Tests whether the GetQuery method returns the correct value when given "/commits".
         /// </summary>
         [TestMethod]

--- a/GitHub Scraper/GitHubScraper.Tests/Services/GitHub Service Test.cs
+++ b/GitHub Scraper/GitHubScraper.Tests/Services/GitHub Service Test.cs
@@ -27,7 +27,7 @@ namespace GitHubScraper.Tests.Services
         /// Checks whether the GetIssues method returns a list of issues.
         /// </summary>
         [TestMethod]
-        public void TestGetIssues()
+        public async Task TestGetIssues()
         {
             List<IssueModel> mockIssue =
             [
@@ -56,11 +56,11 @@ namespace GitHubScraper.Tests.Services
             ];
 
             Mock<IGitHubClient> _mockGitHubClient = new();
-            _mockGitHubClient.Setup(ghc => ghc.GetIssues(It.IsAny<string>(), It.IsAny<DateTime>()).Result).Returns(mockIssue);
+            _mockGitHubClient.Setup(ghc => ghc.GetIssues(It.IsAny<string>(), It.IsAny<DateTime>())).ReturnsAsync(mockIssue);
 
             GitHubService _gitHubService = new(_MockLogger.Object, _mockGitHubClient.Object);
 
-            List <IssueModel> issues = _gitHubService.GetIssues("Unit-Test", _MockClock.Object.DefaultDate);
+            List <IssueModel> issues = await _gitHubService.GetIssues("Unit-Test", _MockClock.Object.DefaultDate);
 
             Assert.IsTrue(issues.Count > 0);
             Assert.AreEqual(mockIssue[0].Id, issues[0].Id);
@@ -70,25 +70,68 @@ namespace GitHubScraper.Tests.Services
         /// Checks whether the GetIssues method returns an empty list of issues.
         /// </summary>
         [TestMethod]
-        public void TestGetIssuesEmpty()
+        public async Task TestGetIssuesEmpty()
         {
             List<IssueModel> mockIssue = [];
 
             Mock<IGitHubClient> _mockGitHubClient = new();
-            _mockGitHubClient.Setup(ghc => ghc.GetIssues(It.IsAny<string>(), It.IsAny<DateTime>()).Result).Returns(mockIssue);
+            _mockGitHubClient.Setup(ghc => ghc.GetIssues(It.IsAny<string>(), It.IsAny<DateTime>())).ReturnsAsync(mockIssue);
 
             GitHubService _gitHubService = new(_MockLogger.Object, _mockGitHubClient.Object);
 
-            List<IssueModel> issues = _gitHubService.GetIssues("Unit-Test", Date);
+            List<IssueModel> issues = await _gitHubService.GetIssues("Unit-Test", Date);
 
             Assert.AreEqual(0, issues.Count);
+        }
+
+        /// <summary>
+        /// Checks whether the GetBranches method returns a list of branches.
+        /// </summary>
+        [TestMethod]
+        public async Task TestGetBranches()
+        {
+            List<BranchModel> mockBranch =
+            [
+                new()
+                {
+                    Name = "main"
+                }
+            ];
+
+            Mock<IGitHubClient> _mockGitHubClient = new();
+            _mockGitHubClient.Setup(ghc => ghc.GetBranches(It.IsAny<string>())).ReturnsAsync(mockBranch);
+
+            GitHubService _gitHubService = new(_MockLogger.Object, _mockGitHubClient.Object);
+
+            List<BranchModel> branches = await _gitHubService.GetBranches("Unit-Test");
+
+            Assert.IsTrue(branches.Count > 0);
+            Assert.AreEqual(mockBranch[0].Name, branches[0].Name);
+        }
+
+        /// <summary>
+        /// Checks whether the GetBranches method returns an empty list of branches.
+        /// </summary>
+        [TestMethod]
+        public async Task TestGetBranchesEmpty()
+        {
+            List<BranchModel> mockBranch = [];
+
+            Mock<IGitHubClient> _mockGitHubClient = new();
+            _mockGitHubClient.Setup(ghc => ghc.GetBranches(It.IsAny<string>())).ReturnsAsync(mockBranch);
+
+            GitHubService _gitHubService = new(_MockLogger.Object, _mockGitHubClient.Object);
+
+            List<BranchModel> branches = await _gitHubService.GetBranches("Unit-Test");
+
+            Assert.AreEqual(0, branches.Count);
         }
 
         /// <summary>
         /// Checks whether the GetCommits method returns a list of commits.
         /// </summary>
         [TestMethod]
-        public void TestGetCommits()
+        public async Task TestGetCommits()
         {
             List<CommitModel> mockCommit =
             [
@@ -112,11 +155,11 @@ namespace GitHubScraper.Tests.Services
             ];
 
             Mock<IGitHubClient> _mockGitHubClient = new();
-            _mockGitHubClient.Setup(ghc => ghc.GetCommits(It.IsAny<string>(), It.IsAny<DateTime>()).Result).Returns(mockCommit);
+            _mockGitHubClient.Setup(ghc => ghc.GetCommits(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string>())).ReturnsAsync(mockCommit);
 
             GitHubService _gitHubService = new(_MockLogger.Object, _mockGitHubClient.Object);
 
-            List<CommitModel> commits = _gitHubService.GetCommits("Unit-Test", _MockClock.Object.DefaultDate);
+            List<CommitModel> commits = await _gitHubService.GetCommits("Unit-Test", _MockClock.Object.DefaultDate, "main");
 
             Assert.IsTrue(commits.Count > 0);
             Assert.AreEqual(mockCommit[0].Sha, commits[0].Sha);
@@ -126,16 +169,16 @@ namespace GitHubScraper.Tests.Services
         /// Checks whether the GetCommits method returns an empty list of commits.
         /// </summary>
         [TestMethod]
-        public void TestGetCommitsEmpty()
+        public async Task TestGetCommitsEmpty()
         {
             List<CommitModel> mockCommit = [];
 
             Mock<IGitHubClient> _mockGitHubClient = new();
-            _mockGitHubClient.Setup(ghc => ghc.GetCommits(It.IsAny<string>(), It.IsAny<DateTime>()).Result).Returns(mockCommit);
+            _mockGitHubClient.Setup(ghc => ghc.GetCommits(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string>())).ReturnsAsync(mockCommit);
 
             GitHubService _gitHubService = new(_MockLogger.Object, _mockGitHubClient.Object);
 
-            List<CommitModel> commits = _gitHubService.GetCommits("Unit-Test", Date);
+            List<CommitModel> commits = await _gitHubService.GetCommits("Unit-Test", Date, "main");
 
             Assert.AreEqual(0, commits.Count);
         }
@@ -144,7 +187,7 @@ namespace GitHubScraper.Tests.Services
         /// Checks whether the GetPullRequests method returns a list of pull requests.
         /// </summary>
         [TestMethod]
-        public void TestGetPullRequests()
+        public async Task TestGetPullRequests()
         {
             List<PullRequestModel> mockPullRequest =
             [
@@ -175,11 +218,11 @@ namespace GitHubScraper.Tests.Services
             ];
 
             Mock<IGitHubClient> _mockGitHubClient = new();
-            _mockGitHubClient.Setup(ghc => ghc.GetPullRequests(It.IsAny<string>(), It.IsAny<DateTime>()).Result).Returns(mockPullRequest);
+            _mockGitHubClient.Setup(ghc => ghc.GetPullRequests(It.IsAny<string>(), It.IsAny<DateTime>())).ReturnsAsync(mockPullRequest);
 
             GitHubService _gitHubService = new(_MockLogger.Object, _mockGitHubClient.Object);
 
-            List<PullRequestModel> pullRequests = _gitHubService.GetPullRequests("Unit-Test", _MockClock.Object.DefaultDate);
+            List<PullRequestModel> pullRequests = await _gitHubService.GetPullRequests("Unit-Test", _MockClock.Object.DefaultDate);
 
             Assert.IsTrue(pullRequests.Count > 0);
             Assert.AreEqual(mockPullRequest[0].Id, pullRequests[0].Id);
@@ -189,16 +232,16 @@ namespace GitHubScraper.Tests.Services
         /// Checks whether the GetPullRequests method returns an empty list of pull requests.
         /// </summary>
         [TestMethod]
-        public void TestGetPullRequestsEmpty()
+        public async Task TestGetPullRequestsEmpty()
         {
             List<PullRequestModel> mockPullRequest = [];
 
             Mock<IGitHubClient> _mockGitHubClient = new();
-            _mockGitHubClient.Setup(ghc => ghc.GetPullRequests(It.IsAny<string>(), It.IsAny<DateTime>()).Result).Returns(mockPullRequest);
+            _mockGitHubClient.Setup(ghc => ghc.GetPullRequests(It.IsAny<string>(), It.IsAny<DateTime>())).ReturnsAsync(mockPullRequest);
 
             GitHubService _gitHubService = new(_MockLogger.Object, _mockGitHubClient.Object);
 
-            List<PullRequestModel> pullRequests = _gitHubService.GetPullRequests("Unit-Test", _MockClock.Object.DefaultDate);
+            List<PullRequestModel> pullRequests = await _gitHubService.GetPullRequests("Unit-Test", _MockClock.Object.DefaultDate);
 
             Assert.AreEqual(0, pullRequests.Count);
         }
@@ -207,7 +250,7 @@ namespace GitHubScraper.Tests.Services
         /// Checks whether the GetWorkflowRuns method returns a list of workflow runs.
         /// </summary>
         [TestMethod]
-        public void TestGetWorkflowRuns()
+        public async Task TestGetWorkflowRuns()
         {
             List<WorkflowRunModel> mockWorkflowRun =
             [
@@ -230,11 +273,11 @@ namespace GitHubScraper.Tests.Services
             ];
 
             Mock<IGitHubClient> _mockGitHubClient = new();
-            _mockGitHubClient.Setup(ghc => ghc.GetWorkflowRuns(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>()).Result).Returns(mockWorkflowRun);
+            _mockGitHubClient.Setup(ghc => ghc.GetWorkflowRuns(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>())).ReturnsAsync(mockWorkflowRun);
 
             GitHubService _gitHubService = new(_MockLogger.Object, _mockGitHubClient.Object);
 
-            List<WorkflowRunModel> workflowRuns = _gitHubService.GetWorkflowRuns("Unit-Test", "Test Workflow", _MockClock.Object.DefaultDate);
+            List<WorkflowRunModel> workflowRuns = await _gitHubService.GetWorkflowRuns("Unit-Test", "Test Workflow", _MockClock.Object.DefaultDate);
 
             Assert.IsTrue(workflowRuns.Count > 0);
             Assert.AreEqual(mockWorkflowRun[0].Id, workflowRuns[0].Id);
@@ -244,16 +287,16 @@ namespace GitHubScraper.Tests.Services
         /// Checks whether the GetWorkflowRuns method returns an empty list of workflow runs.
         /// </summary>
         [TestMethod]
-        public void TestGetWorkflowRunsEmpty()
+        public async Task TestGetWorkflowRunsEmpty()
         {
             List<WorkflowRunModel> mockWorkflowRun = [];
 
             Mock<IGitHubClient> _mockGitHubClient = new();
-            _mockGitHubClient.Setup(ghc => ghc.GetWorkflowRuns(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>()).Result).Returns(mockWorkflowRun);
+            _mockGitHubClient.Setup(ghc => ghc.GetWorkflowRuns(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>())).ReturnsAsync(mockWorkflowRun);
 
             GitHubService _gitHubService = new(_MockLogger.Object, _mockGitHubClient.Object);
 
-            List<WorkflowRunModel> workflowRuns = _gitHubService.GetWorkflowRuns("Unit-Test", "Test Workflow", _MockClock.Object.DefaultDate);
+            List<WorkflowRunModel> workflowRuns = await _gitHubService.GetWorkflowRuns("Unit-Test", "Test Workflow", _MockClock.Object.DefaultDate);
 
             Assert.AreEqual(0, workflowRuns.Count);
         }
@@ -262,7 +305,7 @@ namespace GitHubScraper.Tests.Services
         /// Checks whether the GetReleases method returns a list of releases.
         /// </summary>
         [TestMethod]
-        public void TestGetReleases()
+        public async Task TestGetReleases()
         {
             List<ReleaseModel> mockRelease =
             [
@@ -290,11 +333,11 @@ namespace GitHubScraper.Tests.Services
             ];
 
             Mock<IGitHubClient> _mockGitHubClient = new();
-            _mockGitHubClient.Setup(ghc => ghc.GetReleases(It.IsAny<string>(), It.IsAny<DateTime>()).Result).Returns(mockRelease);
+            _mockGitHubClient.Setup(ghc => ghc.GetReleases(It.IsAny<string>(), It.IsAny<DateTime>())).ReturnsAsync(mockRelease);
 
             GitHubService _gitHubService = new(_MockLogger.Object, _mockGitHubClient.Object);
 
-            List<ReleaseModel> releases = _gitHubService.GetReleases("Unit-Test", _MockClock.Object.DefaultDate);
+            List<ReleaseModel> releases = await _gitHubService.GetReleases("Unit-Test", _MockClock.Object.DefaultDate);
 
             Assert.IsTrue(releases.Count > 0);
             Assert.AreEqual(mockRelease[0].Id, releases[0].Id);
@@ -304,16 +347,16 @@ namespace GitHubScraper.Tests.Services
         /// Checks whether the GetReleases method returns an empty list of releases.
         /// </summary>
         [TestMethod]
-        public void TestGetReleasesEmpty()
+        public async Task TestGetReleasesEmpty()
         {
             List<ReleaseModel> mockRelease = [];
 
             Mock<IGitHubClient> _mockGitHubClient = new();
-            _mockGitHubClient.Setup(ghc => ghc.GetReleases(It.IsAny<string>(), It.IsAny<DateTime>()).Result).Returns(mockRelease);
+            _mockGitHubClient.Setup(ghc => ghc.GetReleases(It.IsAny<string>(), It.IsAny<DateTime>())).ReturnsAsync(mockRelease);
 
             GitHubService _gitHubService = new(_MockLogger.Object, _mockGitHubClient.Object);
 
-            List<ReleaseModel> releases = _gitHubService.GetReleases("Unit-Test", _MockClock.Object.DefaultDate);
+            List<ReleaseModel> releases = await _gitHubService.GetReleases("Unit-Test", _MockClock.Object.DefaultDate);
 
             Assert.AreEqual(0, releases.Count);
         }

--- a/GitHub Scraper/GitHubScraper/Abstractions/IGitHub Client.cs
+++ b/GitHub Scraper/GitHubScraper/Abstractions/IGitHub Client.cs
@@ -10,7 +10,8 @@ namespace GitHubScraper.Abstractions
     public interface IGitHubClient
     {
         Task<List<IssueModel>> GetIssues(string repository, DateTime lastRunDate);
-        Task<List<CommitModel>> GetCommits(string repository, DateTime lastRunDate);
+        Task<List<BranchModel>> GetBranches(string repository);
+        Task<List<CommitModel>> GetCommits(string repository, DateTime lastRunDate, string sha);
         Task<List<PullRequestModel>> GetPullRequests(string repository, DateTime lastRunDate);
         Task<List<WorkflowRunModel>> GetWorkflowRuns(string repository, string workflow, DateTime lastRunDate);
         Task<List<ReleaseModel>> GetReleases(string repository, DateTime lastRunDate);

--- a/GitHub Scraper/GitHubScraper/Converters/GitHub Converter.cs
+++ b/GitHub Scraper/GitHubScraper/Converters/GitHub Converter.cs
@@ -11,6 +11,7 @@ namespace GitHubScraper.Converters
             return endpoint switch
             {
                 "/issues" => "?state=all&sort=updated&per_page=100",
+                "/branches" => "?per_page=100",
                 "/commits" => "?per_page=100",
                 "/pulls" => "?state=all&sort=updated&direction=desc&per_page=100",
                 "/runs" => "?per_page=100",

--- a/GitHub Scraper/GitHubScraper/GitHubScraper.csproj
+++ b/GitHub Scraper/GitHubScraper/GitHubScraper.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>favicon.ico</PackageIcon>
     <RepositoryUrl>https://github.com/LegendarySpork9/Other-Projects/tree/main/GitHub%20Scraper</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GitHub Scraper/GitHubScraper/Implementations/GitHub Client Wrapper.cs
+++ b/GitHub Scraper/GitHubScraper/Implementations/GitHub Client Wrapper.cs
@@ -99,9 +99,79 @@ namespace GitHubScraper.Implementations
         }
 
         /// <summary>
+        /// Returns a list of the branches for the repository.
+        /// </summary>
+        public async Task<List<BranchModel>> GetBranches(string repository)
+        {
+            List<BranchModel> branches = [];
+            int page = 1;
+
+            try
+            {
+                string url = BuildURL("/branches", repository, null);
+
+                _Logger.LogMessage(StandardValues.LoggerValues.Debug, $"URL: {url}");
+
+                RestClient client = new(url);
+                client.AddDefaultHeader("Authorization", $"Bearer {_Options.BearerToken}");
+
+                _Logger.LogMessage(StandardValues.LoggerValues.Debug, "Configured Rest Client");
+
+                while (true)
+                {
+                    RestRequest request = new()
+                    {
+                        Method = Method.Get
+                    };
+                    request.AddParameter("page", page);
+
+                    _Logger.LogMessage(StandardValues.LoggerValues.Debug, $"Page: {page}");
+                    _Logger.LogMessage(StandardValues.LoggerValues.Debug, "Configured Rest Request");
+                    _Logger.LogMessage(StandardValues.LoggerValues.Debug, "Sending Request");
+
+                    RestResponse response = await client.ExecuteAsync(request);
+
+                    _Logger.LogMessage(StandardValues.LoggerValues.Debug, $"Response Code: {response.StatusCode}");
+                    _Logger.LogMessage(StandardValues.LoggerValues.Debug, $"Response Message: {response.ErrorException?.Message ?? response.Content}");
+
+                    if (response.StatusCode == System.Net.HttpStatusCode.OK && response.Content != null)
+                    {
+                        List<BranchModel> apiBranches = JsonConvert.DeserializeObject<List<BranchModel>>(response.Content) ?? [];
+
+                        _Logger.LogMessage(StandardValues.LoggerValues.Debug, $"Branches Returned: {apiBranches.Count}");
+
+                        if (apiBranches.Count > 0)
+                        {
+                            branches.AddRange(apiBranches);
+                            page++;
+                        }
+
+                        else
+                        {
+                            break;
+                        }
+                    }
+
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            catch (Exception ex)
+            {
+                _Logger.LogMessage(StandardValues.LoggerValues.Warning, ex.Message);
+                _Logger.LogMessage(StandardValues.LoggerValues.Error, ex.ToString());
+            }
+
+            return branches;
+        }
+
+        /// <summary>
         /// Returns a list of the commits for the repository.
         /// </summary>
-        public async Task<List<CommitModel>> GetCommits(string repository, DateTime lastRunDate)
+        public async Task<List<CommitModel>> GetCommits(string repository, DateTime lastRunDate, string sha)
         {
             List<CommitModel> commits = [];
             int page = 1;
@@ -109,6 +179,7 @@ namespace GitHubScraper.Implementations
             try
             {
                 string url = BuildURL("/commits", repository, lastRunDate);
+                url += $"&sha={Uri.EscapeDataString(sha)}";
 
                 _Logger.LogMessage(StandardValues.LoggerValues.Debug, $"URL: {url}");
 

--- a/GitHub Scraper/GitHubScraper/Models/Branch Model.cs
+++ b/GitHub Scraper/GitHubScraper/Models/Branch Model.cs
@@ -1,0 +1,11 @@
+﻿// Copyright © - 16/03/2026 - Toby Hunter
+namespace GitHubScraper.Models
+{
+    /// <summary>
+    /// Stores information about the branch.
+    /// </summary>
+    public class BranchModel
+    {
+        public required string Name { get; set; }
+    }
+}

--- a/GitHub Scraper/GitHubScraper/Services/Application Service.cs
+++ b/GitHub Scraper/GitHubScraper/Services/Application Service.cs
@@ -130,9 +130,22 @@ namespace GitHubScraper.Services
                 DateTime lastRunDate = await _databaseService.GetLastRunDate(repository);
                 List<IssueModel> existingIssues = await _databaseService.GetIssues(repository);
 
-                List<IssueModel> issues = _gitHubService.GetIssues(repository, lastRunDate);
-                List<CommitModel> commits = _gitHubService.GetCommits(repository, lastRunDate);
-                List<PullRequestModel> pullRequests = _gitHubService.GetPullRequests(repository, lastRunDate);
+                List<IssueModel> issues = await _gitHubService.GetIssues(repository, lastRunDate);
+                List<BranchModel> branches = await _gitHubService.GetBranches(repository);
+                List<CommitModel> commits = [];
+
+                foreach (BranchModel branch in branches)
+                {
+                    List<CommitModel> branchCommits = await _gitHubService.GetCommits(repository, lastRunDate, branch.Name);
+
+                    if (branchCommits.Count > 0)
+                    {
+                        commits.AddRange(branchCommits);
+                    }
+                }
+
+                commits = [.. commits.OrderBy(c => c.Commit.Committer.Date)];
+                List<PullRequestModel> pullRequests = await _gitHubService.GetPullRequests(repository, lastRunDate);
                 List<WorkflowModel> workflows = [];
 
                 int totalWorkflowRuns = 0;
@@ -141,7 +154,7 @@ namespace GitHubScraper.Services
                 {
                     foreach (string workflow in AppSettingsModel.Workflows)
                     {
-                        List<WorkflowRunModel> workflowRuns = _gitHubService.GetWorkflowRuns(repository, workflow, lastRunDate);
+                        List<WorkflowRunModel> workflowRuns = await _gitHubService.GetWorkflowRuns(repository, workflow, lastRunDate);
 
                         if (workflowRuns.Count > 0)
                         {
@@ -156,7 +169,7 @@ namespace GitHubScraper.Services
                     }
                 }
 
-                List<ReleaseModel> releases = _gitHubService.GetReleases(repository, lastRunDate);
+                List<ReleaseModel> releases = await _gitHubService.GetReleases(repository, lastRunDate);
 
                 await _databaseService.OutputIssues(repository, issues);
                 await _databaseService.OutputCommits(repository, commits);

--- a/GitHub Scraper/GitHubScraper/Services/Application Service.cs
+++ b/GitHub Scraper/GitHubScraper/Services/Application Service.cs
@@ -144,7 +144,7 @@ namespace GitHubScraper.Services
                     }
                 }
 
-                commits = [.. commits.OrderBy(c => c.Commit.Committer.Date)];
+                commits = [.. commits.DistinctBy(c => c.Sha).OrderBy(c => c.Commit.Committer.Date)];
                 List<PullRequestModel> pullRequests = await _gitHubService.GetPullRequests(repository, lastRunDate);
                 List<WorkflowModel> workflows = [];
 

--- a/GitHub Scraper/GitHubScraper/Services/GitHub Service.cs
+++ b/GitHub Scraper/GitHubScraper/Services/GitHub Service.cs
@@ -24,11 +24,11 @@ namespace GitHubScraper.Services
         /// <summary>
         /// Returns a list of the issues for the repository.
         /// </summary>
-        public List<IssueModel> GetIssues(string repository, DateTime lastRunDate)
+        public async Task<List<IssueModel>> GetIssues(string repository, DateTime lastRunDate)
         {
             _Logger.LogMessage(StandardValues.LoggerValues.Info, $"Fetching issues from GitHub for {repository} repository from {lastRunDate:dd/MM/yyyy HH:mm:ss}");
 
-            List<IssueModel> issues = _GitHubClient.GetIssues(repository, lastRunDate).Result;
+            List<IssueModel> issues = await _GitHubClient.GetIssues(repository, lastRunDate);
             TextInfo textInfo = CultureInfo.CurrentCulture.TextInfo;
 
             _Logger.LogMessage(StandardValues.LoggerValues.Info, $"Filtering out pull requests in favour of pull request endpoint data");
@@ -80,13 +80,26 @@ namespace GitHubScraper.Services
         }
 
         /// <summary>
+        /// Returns a list of the branches for the repository.
+        /// </summary>
+        public async Task<List<BranchModel>> GetBranches(string repository)
+        {
+            _Logger.LogMessage(StandardValues.LoggerValues.Info, $"Fetching branches from GitHub for {repository} repository");
+
+            List<BranchModel> branches = await _GitHubClient.GetBranches(repository);
+
+            _Logger.LogMessage(StandardValues.LoggerValues.Info, $"Fetched {branches.Count} branch(s) from GitHub for {repository} repository");
+            return branches;
+        }
+
+        /// <summary>
         /// Returns a list of the commits for the repository.
         /// </summary>
-        public List<CommitModel> GetCommits(string repository, DateTime lastRunDate)
+        public async Task<List<CommitModel>> GetCommits(string repository, DateTime lastRunDate, string sha)
         {
-            _Logger.LogMessage(StandardValues.LoggerValues.Info, $"Fetching commits from GitHub for {repository} repository from {lastRunDate:dd/MM/yyyy HH:mm:ss}");
+            _Logger.LogMessage(StandardValues.LoggerValues.Info, $"Fetching commits from GitHub for {repository} repository, {sha} branch from {lastRunDate:dd/MM/yyyy HH:mm:ss}");
 
-            List<CommitModel> commits = _GitHubClient.GetCommits(repository, lastRunDate).Result;
+            List<CommitModel> commits = await _GitHubClient.GetCommits(repository, lastRunDate, sha);
 
             foreach (CommitModel commit in commits)
             {
@@ -98,18 +111,18 @@ namespace GitHubScraper.Services
                 _Logger.LogMessage(StandardValues.LoggerValues.Info, $"Filled blanks for commit {commit.Sha}");
             }
 
-            _Logger.LogMessage(StandardValues.LoggerValues.Info, $"Fetched {commits.Count} commit(s) from GitHub for {repository} repository from {lastRunDate:dd/MM/yyyy HH:mm:ss}");
+            _Logger.LogMessage(StandardValues.LoggerValues.Info, $"Fetched {commits.Count} commit(s) from GitHub for {repository} repository, {sha} branch from {lastRunDate:dd/MM/yyyy HH:mm:ss}");
             return [.. commits.OrderBy(c => c.Commit.Committer.Date)];
         }
 
         /// <summary>
         /// Returns a list of the pull requests for the repository.
         /// </summary>
-        public List<PullRequestModel> GetPullRequests(string repository, DateTime lastRunDate)
+        public async Task<List<PullRequestModel>> GetPullRequests(string repository, DateTime lastRunDate)
         {
             _Logger.LogMessage(StandardValues.LoggerValues.Info, $"Fetching pull requests from GitHub for {repository} repository from {lastRunDate:dd/MM/yyyy HH:mm:ss}");
 
-            List<PullRequestModel> pullRequests = _GitHubClient.GetPullRequests(repository, lastRunDate).Result;
+            List<PullRequestModel> pullRequests = await _GitHubClient.GetPullRequests(repository, lastRunDate);
             TextInfo textInfo = CultureInfo.CurrentCulture.TextInfo;
 
             foreach (PullRequestModel pullRequest in pullRequests)
@@ -161,11 +174,11 @@ namespace GitHubScraper.Services
         /// <summary>
         /// Returns a list of the workflow runs for the repository and workflow.
         /// </summary>
-        public List<WorkflowRunModel> GetWorkflowRuns(string repository, string workflow, DateTime lastRunDate)
+        public async Task<List<WorkflowRunModel>> GetWorkflowRuns(string repository, string workflow, DateTime lastRunDate)
         {
             _Logger.LogMessage(StandardValues.LoggerValues.Info, $"Fetching workflow runs from GitHub for {workflow} workflow in {repository} repository from {lastRunDate:dd/MM/yyyy HH:mm:ss}");
 
-            List<WorkflowRunModel> workflowRuns = _GitHubClient.GetWorkflowRuns(repository, workflow, lastRunDate).Result;
+            List<WorkflowRunModel> workflowRuns = await _GitHubClient.GetWorkflowRuns(repository, workflow, lastRunDate);
             TextInfo textInfo = CultureInfo.CurrentCulture.TextInfo;
 
             foreach (WorkflowRunModel workflowRun in workflowRuns)
@@ -203,11 +216,11 @@ namespace GitHubScraper.Services
         /// <summary>
         /// Returns a list of the releases for the repository.
         /// </summary>
-        public List<ReleaseModel> GetReleases(string repository, DateTime lastRunDate)
+        public async Task<List<ReleaseModel>> GetReleases(string repository, DateTime lastRunDate)
         {
             _Logger.LogMessage(StandardValues.LoggerValues.Info, $"Fetching releases from GitHub for {repository} repository from {lastRunDate:dd/MM/yyyy HH:mm:ss}");
 
-            List<ReleaseModel> releases = _GitHubClient.GetReleases(repository, lastRunDate).Result;
+            List<ReleaseModel> releases = await _GitHubClient.GetReleases(repository, lastRunDate);
 
             foreach (ReleaseModel release in releases)
             {


### PR DESCRIPTION
## Commit Call Fix
- Added a new GitHub call to fetch all the branches in the repo.
- Changed the GetCommit method to get the commits for each branch.
- Added unit tests for the new call.
- Amended the unit tests for the GetCommits method.

## Distinct
- Changed the list sort to also remove duplicate commits.

## Assembly Build
- Updated the version number.